### PR TITLE
PR: ai-fix/22.05.25-11.43

### DIFF
--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:blabla
+          image: nginx:blech # replace with the correct tag or image registry where your image is hosted


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-22T11:21:44+02:00] app-namespace/nginx: Failed - Failed to pull image "nginx:blabla": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/nginx:blabla": failed to resolve reference "docker.io/library/nginx:blabla": docker.io/library/nginx:blabla: not found
[2025-05-22T11:21:44+02:00] app-namespace/nginx: Failed - Error: ErrImagePull
[2025-05-22T11:22:12+02:00] app-namespace/nginx: Failed - Error: ImagePullBackOff
