### PR TITLE
PR: ai-fix/25.05.25-22.44

### DIFF
--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:latest
+          image: docker.io/alpine:latest

--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: app-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-25T22:30:09+02:00] app-namespace/nginx-6d59f979b9-zcg46: Failed - Failed to pull image "your_correct_image_name:your_correct_tag": failed to pull and unpack image "docker.io/library/your_correct_image_name:your_correct_tag": failed to resolve reference "docker.io/library/your_correct_image_name:your_correct_tag": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
[2025-05-25T22:30:09+02:00] app-namespace/nginx-6d59f979b9-zcg46: Failed - Error: ErrImagePull
[2025-05-25T22:30:32+02:00] app-namespace/nginx-6d59f979b9-zcg46: Failed - Error: ImagePullBackOff

After updating the deployment its status changed:
