### PR TITLE
PR: ai-fix/25.05.25-22.46

### DIFF
--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:latest
+          image: docker.io/alpine:latest

--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: app-namespace
 spec:
   replicas: 1
-  selector:
+  selector: 
     matchLabels:
       app: nginx
   template:
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:latest
+          image: "nginx:blabla"
           ports:
             - containerPort: 80

--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -15,4 +15,6 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: docker.io/alpine:latest
+          image: nginx:latest
+          ports:
+            - containerPort: 80

--- a/kube/nginx.yaml
+++ b/kube/nginx.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: app-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-25T22:44:34+02:00] app-namespace/nginx-588f8cfc8c-cnwww: BackOff - Back-off restarting failed container nginx in pod nginx-588f8cfc8c-cnwww_app-namespace(80fefbd1-5feb-45b2-b76f-b1c0bf3363f7)
[2025-05-25T22:44:46+02:00] app-namespace/nginx-588f8cfc8c-cnwww: BackOff - Back-off restarting failed container nginx in pod nginx-588f8cfc8c-cnwww_app-namespace(80fefbd1-5feb-45b2-b76f-b1c0bf3363f7)

After updating the deployment its status changed:
