### PR TITLE
PR: ai-fix/26.05.25-11.29

### DIFF
--- a/kube/app_cluster/nginx.yaml
+++ b/kube/app_cluster/nginx.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:blabla
+          image: nginx


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-26T11:28:54Z] app-namespace/nginx-f4987568f-dmct4: Failed - Failed to pull image "nginx:blabla": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/nginx:blabla": failed to resolve reference "docker.io/library/nginx:blabla": docker.io/library/nginx:blabla: not found
[2025-05-26T11:28:54Z] app-namespace/nginx-f4987568f-dmct4: Failed - Error: ErrImagePull
[2025-05-26T11:28:55Z] app-namespace/nginx-f4987568f-dmct4: Failed - Error: ImagePullBackOff
