### PR TITLE
PR: ai-fix/26.05.25-11.51

### DIFF
--- a/kube/app_cluster/nginx.yaml
+++ b/kube/app_cluster/nginx.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:blabla
+          image: nginx:latest


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-26T11:50:01Z] app-namespace/nginx-76b8f6fbcc-4dqr7: Failed - Error: ImagePullBackOff
