### PR TITLE
PR: ai-fix/26.05.25-13.03

### DIFF
--- a/kube/app_cluster/nginx.yaml
+++ b/kube/app_cluster/nginx.yaml
@@ -19,5 +19,4 @@ spec:
           resources:
             limits:
               cpu: "10m"
-              memory: "1Mi"
-      
+              memory: "30Mi"


### PR DESCRIPTION
This PR proposes AI-generated fix for these errors: 
[2025-05-26T13:01:42Z] app-namespace/nginx-855855545-sn88x: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:01:45Z] app-namespace/nginx-58fd88495c-cbg9v: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:01:57Z] app-namespace/nginx-58fd88495c-cbg9v: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:01:59Z] app-namespace/nginx-855855545-sn88x: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:02:12Z] app-namespace/nginx-58fd88495c-cbg9v: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:02:18Z] app-namespace/nginx-855855545-sn88x: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
[2025-05-26T13:02:28Z] app-namespace/nginx-58fd88495c-cbg9v: FailedCreatePodSandBox - Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
